### PR TITLE
Working repo again: bump Wine/DXMT, detach from Terminal, opt-in GPTK backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For developer details, see the [Developer README](README_DEV.md).
    - `Steam (Merlot).app` to launch Steam without game-specific presets.
    - A game launcher, for example `Binding of Isaac (Merlot).app`, to use settings optimized for that game.
 2. If macOS blocks it, right-click the app -> `Open` -> confirm `Open`.
-3. Keep the Terminal window open while Steam is running. Do not close the Terminal window, or Steam and any running game will close immediately.
+3. After Steam launches, the Terminal window prints the Steam log path and can be closed. Steam stays running in the background. (Set `MERLOT_DETACH=0` if you prefer the old foreground behavior where closing Terminal kills Steam.)
 
 `Merlot Apps` includes `Steam (Merlot).app` plus ready-made launchers for supported games in this repository.
 Each game launcher includes presets and tweaks optimized for that game.
@@ -52,7 +52,7 @@ If you want, you can add your own config in `merlot_configs/` and run `install_m
 1. In Finder, locate the unzipped folder.
 2. Double-click `run.command`.
 3. If macOS blocks it, right-click `run.command` -> `Open` -> confirm `Open`.
-4. Keep the Terminal window open while Steam is running. Do not close the Terminal window, or Steam and any running game will close immediately.
+4. After Steam launches, the Terminal window prints the Steam log path and can be closed. Steam stays running in the background. (Set `MERLOT_DETACH=0` if you prefer the old foreground behavior where closing Terminal kills Steam.)
 
 Use this option when you want the general Steam-in-Wine setup instead of a launcher tailored to a specific game.
 
@@ -67,7 +67,7 @@ If you are familiar with Terminal and bash, you can also customize launch option
 
 1. In Steam, use the menu: `Steam` -> `Exit`.
 2. Wait until Steam fully closes.
-3. Close Terminal.
+3. You can close Terminal at any time; with the default `MERLOT_DETACH=1` behavior, Steam is detached from it.
 
 ## Uninstall
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -26,10 +26,20 @@ https://www.reddit.com/r/macgaming/comments/1r8vsnj/how_to_play_windows_steam_ga
   - downloads `SteamSetup.exe` into `STEAM_SETUP` (defaults to `/tmp/SteamSetup.exe`)
   - runs the installer via Wine
   - deletes `STEAM_SETUP` after Steam is detected in the prefix
-- DXMT:
-  - downloads and installs into `DXMT_ROOT` (defaults to `~/DXMT`)
-  - enables it via `WINEDLLPATH_PREPEND`
-  - defaults `DXMT_LOG_LEVEL` to `error` unless already set by the caller
+- D3D translation backend (chosen by `GPTK_PATH`):
+  - Default (DXMT):
+    - downloads and installs into `DXMT_ROOT` (defaults to `~/DXMT`)
+    - enables it via `WINEDLLPATH_PREPEND`
+    - defaults `DXMT_LOG_LEVEL` to `error` unless already set by the caller
+  - Opt-in (Apple Game Porting Toolkit / D3DMetal):
+    - activated by setting `GPTK_PATH` to the GPTK root or directly to the folder containing its DLLs
+    - common layouts are probed (`<path>`, `<path>/redist/lib/external`, `<path>/lib/external`, `<path>/lib`, `<path>/Libraries`)
+    - copies the D3DMetal DLLs into `${WINEPREFIX}/drive_c/windows/system32/` and sets `WINEDLLOVERRIDES=d3d9,d3d10core,d3d11,d3d12,d3d12core,dxgi=n` (unless the caller already set `WINEDLLOVERRIDES`)
+    - GPTK is **not** downloaded by this script -- Apple's EULA forbids redistribution, so you must obtain it from developer.apple.com yourself
+    - a dedicated prefix (e.g. `WINEPREFIX=~/.wine-steam-gptk`) is recommended so GPTK and DXMT DLLs do not accumulate in the same prefix
+- Launch mode:
+  - Default (`MERLOT_DETACH=1`) runs Steam with `nohup ... & disown`, redirecting stdout/stderr to `${MERLOT_STEAM_LOG}` (defaults to `${TMPDIR:-/tmp}/merlot-steam.log`). The Terminal window can be closed immediately after launch without killing Steam.
+  - `MERLOT_DETACH=0` preserves the pre-patch foreground behavior (Terminal window must stay open).
 - Wine logging:
   - defaults `WINEDEBUG` to `-all,err+all` unless already set by the caller
 - Writes registry values inside the prefix:
@@ -60,11 +70,27 @@ Defaults are the values in `run.command`.
 - `WINE_MOUSE_WARP_OVERRIDE`
   - Empty keeps Wine default (and removes the key if it was set before)
   - Allowed values: `force`, `enable`, `disable`
+- `GPTK_PATH`
+  - Empty (default) uses DXMT. When set, switches the D3D backend to Apple's Game Porting Toolkit (D3DMetal) and skips the DXMT download.
+  - Point at either the GPTK root directory or the folder containing its DLLs.
+- `MERLOT_DETACH`
+  - `1` (default) detaches Steam from the launching Terminal so the window can be closed without killing Steam.
+  - `0` keeps the old foreground behavior.
+- `MERLOT_STEAM_LOG`
+  - Path to the detached-mode Steam log (default: `${TMPDIR:-/tmp}/merlot-steam.log`).
 
 Example overrides (environment variables):
 
 ```bash
 WINEPREFIX="$HOME/Games/SteamPrefix" WINE_RETINA_MODE=1 ./run.command
+```
+
+GPTK example (user-supplied Game Porting Toolkit, dedicated prefix):
+
+```bash
+WINEPREFIX="$HOME/.wine-steam-gptk" \
+GPTK_PATH="$HOME/Apple-GPTK" \
+./run.command
 ```
 
 ## What `uninstall.command` Removes

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -56,9 +56,10 @@ https://www.reddit.com/r/macgaming/comments/1r8vsnj/how_to_play_windows_steam_ga
 Defaults are the values in `run.command`.
 
 - `WINE_VERSION`
-  - Wine build version to download (default: `11.3`)
+  - Wine build version to download (default: `11.6_1`)
+  - Must exist as a `wine-staging-${WINE_VERSION}-osx64.tar.xz` asset in the [Gcenx macOS Wine builds](https://github.com/Gcenx/macOS_Wine_builds/releases). Gcenx prunes older releases periodically, so this default will need bumping over time.
 - `DXMT_VERSION`
-  - DXMT release version to download (default: `0.73`)
+  - DXMT release version to download (default: `0.74`)
 - `WINE_ROOT`
   - Where Wine is extracted (default: `~/wine-$WINE_VERSION`)
 - `WINEPREFIX`

--- a/run.command
+++ b/run.command
@@ -13,6 +13,14 @@ WINE_BIN="${WINE_APP}/Contents/Resources/wine/bin/wine"
 WINEPREFIX="${WINEPREFIX:-$HOME/.wine-steam-11}"
 STEAM_SETUP="/tmp/SteamSetup.exe"
 DXMT_ROOT="${DXMT_ROOT:-$HOME/DXMT}"
+# GPTK_PATH: optional. When set, the D3D translation backend switches from
+# DXMT (default) to Apple's Game Porting Toolkit (D3DMetal). Point this at
+# either the GPTK root directory or the folder that contains the .dll files
+# (we probe a few common layouts). GPTK is NOT downloaded automatically --
+# Apple's EULA forbids redistribution, so the user must obtain it from
+# developer.apple.com themselves. DXMT is the default precisely because it
+# has no such constraint.
+GPTK_PATH="${GPTK_PATH:-}"
 WINEPREFIX_ALIAS_NAME="${WINEPREFIX_ALIAS_NAME:-WINEPREFIX}"
 WINE_RETINA_MODE="${WINE_RETINA_MODE:-0}" # 1=enable RetinaMode, 0=disable RetinaMode (Default)
 # 1=detach Steam from the Terminal after launch so closing the window doesn't kill it (Default).
@@ -269,6 +277,59 @@ enable_dxmt_env() {
   export WINEDEBUG="${WINEDEBUG:--all,err+all}"
 }
 
+use_gptk() {
+  [[ -n "${GPTK_PATH}" ]]
+}
+
+find_gptk_dll_dir() {
+  local root="$1"
+  local candidates=(
+    "${root}"
+    "${root}/redist/lib/external"
+    "${root}/lib/external"
+    "${root}/lib"
+    "${root}/Libraries"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [[ -f "${c}/d3d11.dll" ]]; then
+      printf '%s\n' "${c}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_gptk_installed() {
+  log "Installing GPTK DLLs into the Wine prefix"
+  [[ -d "${GPTK_PATH}" ]] || die "GPTK_PATH is not a directory: ${GPTK_PATH}"
+
+  local src
+  if ! src="$(find_gptk_dll_dir "${GPTK_PATH}")"; then
+    die "Could not find d3d11.dll under GPTK_PATH=${GPTK_PATH}. Obtain the Game Porting Toolkit from developer.apple.com and point GPTK_PATH at the root (or directly at the folder containing the DLLs)."
+  fi
+
+  local target="${WINEPREFIX}/drive_c/windows/system32"
+  [[ -d "${target}" ]] || die "Prefix system32 not found (is the prefix initialized?): ${target}"
+
+  echo "Copying GPTK DLLs from ${src} to ${target}"
+  local f copied=0
+  for f in "${src}"/*.dll; do
+    [[ -f "${f}" ]] || continue
+    cp -f "${f}" "${target}/"
+    copied=$((copied + 1))
+  done
+  [[ "${copied}" -gt 0 ]] || die "No .dll files found in ${src}"
+  echo "Copied ${copied} DLL(s)."
+}
+
+enable_gptk_env() {
+  log "Enabling GPTK via WINEDLLOVERRIDES"
+  export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:-d3d9,d3d10core,d3d11,d3d12,d3d12core,dxgi=n}"
+  export WINEDEBUG="${WINEDEBUG:--all,err+all}"
+  echo "WINEDLLOVERRIDES=${WINEDLLOVERRIDES}"
+}
+
 launch_steam() {
   log "Launching Steam"
   local steam_exe
@@ -310,8 +371,13 @@ main() {
   ensure_wine_retina_mode "${WINE_RETINA_MODE}"
   ensure_wine_windows_mouse_accel_disabled
   ensure_steam_installed
-  ensure_dxmt_installed
-  enable_dxmt_env
+  if use_gptk; then
+    ensure_gptk_installed
+    enable_gptk_env
+  else
+    ensure_dxmt_installed
+    enable_dxmt_env
+  fi
   launch_steam
 }
 

--- a/run.command
+++ b/run.command
@@ -3,8 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}"
 
-WINE_VERSION="${WINE_VERSION:-11.3}"
-DXMT_VERSION="${DXMT_VERSION:-0.73}"
+WINE_VERSION="${WINE_VERSION:-11.6_1}"
+DXMT_VERSION="${DXMT_VERSION:-0.74}"
 
 WINE_ROOT="${WINE_ROOT:-$HOME/wine-${WINE_VERSION}}"
 WINE_APP="${WINE_ROOT}/Wine Staging.app"

--- a/run.command
+++ b/run.command
@@ -15,6 +15,10 @@ STEAM_SETUP="/tmp/SteamSetup.exe"
 DXMT_ROOT="${DXMT_ROOT:-$HOME/DXMT}"
 WINEPREFIX_ALIAS_NAME="${WINEPREFIX_ALIAS_NAME:-WINEPREFIX}"
 WINE_RETINA_MODE="${WINE_RETINA_MODE:-0}" # 1=enable RetinaMode, 0=disable RetinaMode (Default)
+# 1=detach Steam from the Terminal after launch so closing the window doesn't kill it (Default).
+# 0=keep the original foreground behavior (Terminal window must stay open).
+MERLOT_DETACH="${MERLOT_DETACH:-1}"
+MERLOT_STEAM_LOG="${MERLOT_STEAM_LOG:-${TMPDIR:-/tmp}/merlot-steam.log}"
 # Default before we added this: the value is not set in registry (Wine internal default).
 # Set to force|enable|disable to override, or leave empty to keep default.
 WINE_MOUSE_WARP_OVERRIDE="${WINE_MOUSE_WARP_OVERRIDE:-}"
@@ -271,12 +275,28 @@ launch_steam() {
   steam_exe="$(find_steam_exe || true)"
   [[ -n "${steam_exe}" ]] || die "steam.exe not found."
 
+  local -a steam_cmd=("${WINE_BIN}" "${steam_exe}")
   if [[ -n "${STEAM_GAME_ID:-}" ]]; then
     echo "Launching Steam game ${STEAM_GAME_ID}..."
-    "${WINE_BIN}" "${steam_exe}" -applaunch "${STEAM_GAME_ID}"
-  else
-    "${WINE_BIN}" "${steam_exe}"
+    steam_cmd+=(-applaunch "${STEAM_GAME_ID}")
   fi
+
+  case "${MERLOT_DETACH}" in
+    0)
+      "${steam_cmd[@]}"
+      ;;
+    1)
+      log "Detaching Steam from this Terminal (log: ${MERLOT_STEAM_LOG})"
+      : >"${MERLOT_STEAM_LOG}" || die "Cannot write to ${MERLOT_STEAM_LOG}"
+      nohup "${steam_cmd[@]}" </dev/null >>"${MERLOT_STEAM_LOG}" 2>&1 &
+      disown
+      echo "Steam is running in the background (PID $!). Safe to close this Terminal window."
+      echo "Tail the log with: tail -f ${MERLOT_STEAM_LOG}"
+      ;;
+    *)
+      die "MERLOT_DETACH must be 0 or 1."
+      ;;
+  esac
 }
 
 main() {

--- a/uninstall.command
+++ b/uninstall.command
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-WINE_VERSION="${WINE_VERSION:-11.3}"
+WINE_VERSION="${WINE_VERSION:-11.6_1}"
 WINE_ROOT="${WINE_ROOT:-$HOME/wine-${WINE_VERSION}}"
 WINEPREFIX="${WINEPREFIX:-$HOME/.wine-steam-11}"
 DXMT_ROOT="${DXMT_ROOT:-$HOME/DXMT}"


### PR DESCRIPTION
Three independent commits. Take any subset.

## 1/3: Bump defaults Wine 11.3 → 11.6_1, DXMT 0.73 → 0.74 (commit d32510e)

Gcenx/macOS_Wine_builds has pruned 11.3 from its Releases page, so the hardcoded URL in `main` 404s and fresh clones can't finish the first install step today. The only Wine variants still published are:

- 11.7 (`wine-devel` only, no staging)
- 11.6_1 (`wine-devel` + `wine-staging`) ← used
- 11.0_1 (`wine-stable` only)

Bumping to 11.6_1 preserves the `wine-staging` variant the project is built around and unblocks installation. README_DEV.md now calls out that Gcenx prunes old releases so this default will need periodic bumping, and that `WINE_VERSION` must map to an extant `wine-staging-${WINE_VERSION}-osx64.tar.xz` asset. `uninstall.command`'s default bumped to match so it removes the right `~/wine-11.6_1` directory.

DXMT bumped 0.73 → 0.74 (latest, 2026-03-10) while we're here.

## 2/3: Detach Steam from Terminal by default (commit 72681ad)

Today, closing the Terminal window kills wineserver, Steam, and any running game. The README acknowledges this (`"Keep the Terminal window open while Steam is running"`), but it's an avoidable papercut.

`launch_steam()` now runs wine with `nohup ... </dev/null >log 2>&1 & disown`. stdout/stderr go to `${TMPDIR:-/tmp}/merlot-steam.log` (override via `MERLOT_STEAM_LOG`). After the launch line prints, the Terminal window is safe to close.

- `MERLOT_DETACH=1` (default): the new detached behavior.
- `MERLOT_DETACH=0`: the original foreground behavior, preserved as an escape hatch.

README/README_DEV.md wording softened accordingly.

## 3/3: Opt-in Apple Game Porting Toolkit backend via `GPTK_PATH` (commit 243d43f)

DXMT stays the default — it's freely redistributable and has no EULA constraint, which is why the repo's ergonomics are possible at all. But some users have already downloaded Apple's Game Porting Toolkit from developer.apple.com and want to A/B it against DXMT without leaving the Merlot workflow (D3DMetal covers D3D9 natively, which DXMT does not).

When `GPTK_PATH` is set, `run.command`:
1. Probes common GPTK layouts for a dir containing `d3d11.dll` (flat / `redist/lib/external` / `lib/external` / `lib` / `Libraries`). Dies with a pointer to developer.apple.com if not found.
2. Copies the D3DMetal DLLs into `${WINEPREFIX}/drive_c/windows/system32/`. (This is what Whisky and Kegworks do — more reliable than `WINEDLLPATH_PREPEND` for native PE DLLs.)
3. Sets `WINEDLLOVERRIDES=d3d9,d3d10core,d3d11,d3d12,d3d12core,dxgi=n` (unless the caller already set `WINEDLLOVERRIDES`).
4. Skips the DXMT download/install step.

GPTK is **not** downloaded automatically — Apple's EULA forbids redistribution, so users must obtain it themselves. The README_DEV.md call-out is explicit about this and recommends a dedicated `WINEPREFIX` (e.g. `~/.wine-steam-gptk`) so GPTK and DXMT DLLs don't accumulate in the same prefix.

Example:

```bash
WINEPREFIX="$HOME/.wine-steam-gptk" GPTK_PATH="$HOME/Apple-GPTK" ./run.command
```

## Testing

- `bash -n` clean on `run.command`, `uninstall.command`, `install_merlot.command`, `app/merlot/MerlotLauncher`.
- Unit tests on the GPTK probe across all four supported layouts (flat / redist/lib/external / lib/external / other).
- `nohup ... & disown` pattern verified to survive parent shell exit.
- Wine 11.6_1 staging asset URL + DXMT 0.74 asset URL both verified (302 → download).

## Why together

All three commits are independent — the version bump is strictly required for today's `main` to work at all, the detach fix is a UX cleanup, the GPTK path is opt-in and gated on `GPTK_PATH`. Each lives in its own commit with no cross-dependency, so cherry-picking any subset is fine.