### PR TITLE
Fix Steam client UI rendering as a black window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 WINEPREFIX
 Merlot Apps/
+wrapper/steamwebhelper.exe

--- a/README.md
+++ b/README.md
@@ -78,6 +78,32 @@ If Steam is running, follow the steps in "Stop" first.
 3. It may ask for your macOS password to remove `/Applications/Merlot Apps`.
 4. It will ask for confirmation for each item it wants to remove. Type `y` to remove it, or `n` to skip it (if you want to keep something).
 
+## Troubleshooting
+
+### Steam opens as a black window
+
+Steam's interface is Chromium, and under Wine on Apple Silicon it paints itself
+solid black. The scripts fix this automatically by wrapping Steam's
+`steamwebhelper.exe`, so you normally never see it.
+
+If it happens anyway:
+
+1. Quit Steam completely.
+2. Double-click `run.command` again (or relaunch your Merlot app). It rebuilds
+   and reinstalls the wrapper every launch.
+
+A Steam client update can bring the black window back for one launch, because
+Steam replaces the wrapped file. Relaunching restores it.
+
+Compiling the wrapper needs Homebrew's `mingw-w64`; if you declined the prompt,
+install it with `brew install mingw-w64` and relaunch. Technical details are in
+[`wrapper/README.md`](wrapper/README.md).
+
+### Steam starts but no window appears
+
+A previous crash can leave Chromium lock files behind. `run.command` clears them
+on launch while Steam is stopped, so quit Steam fully and run it again.
+
 ## Notes
 
 - Apple Silicon only. Intel Macs are not supported by this script.
@@ -92,6 +118,9 @@ If Steam is running, follow the steps in "Stop" first.
 - Downloads Wine (Gcenx macOS Wine builds) and sets up a Steam Wine prefix.
 - Downloads and installs Steam into that prefix.
 - Downloads DXMT and enables it for Wine.
+- Builds and installs a small `steamwebhelper` wrapper that stops Steam's own
+  interface from rendering as a black window (see Troubleshooting). The first
+  run offers to install Homebrew's `mingw-w64` to compile it.
 
 `uninstall.command`:
 - Removes files/directories created by `run.command` (with per-item confirmation).

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -37,6 +37,24 @@ https://www.reddit.com/r/macgaming/comments/1r8vsnj/how_to_play_windows_steam_ga
     - copies the D3DMetal DLLs into `${WINEPREFIX}/drive_c/windows/system32/` and sets `WINEDLLOVERRIDES=d3d9,d3d10core,d3d11,d3d12,d3d12core,dxgi=n` (unless the caller already set `WINEDLLOVERRIDES`)
     - GPTK is **not** downloaded by this script -- Apple's EULA forbids redistribution, so you must obtain it from developer.apple.com yourself
     - a dedicated prefix (e.g. `WINEPREFIX=~/.wine-steam-gptk`) is recommended so GPTK and DXMT DLLs do not accumulate in the same prefix
+- Steam CEF UI fix (`MERLOT_CEF_WRAPPER`, on by default):
+  - Steam's client UI renders as a **solid black window** under Wine on Apple
+    Silicon. CEF's ANGLE D3D11 backend cannot query the DXGI adapter, falls back
+    to GLES 2.0 (CEF needs 3.0), disables the GPU, and paints its
+    transparent-background window black. This is not DXMT-specific -- Wine's
+    builtin `d3d11`/`dxgi` hit the same failure.
+  - Builds (once) and deploys `wrapper/` over `steamwebhelper.exe`, which injects
+    `--disable-gpu --single-process` and delegates to the renamed original.
+    Requires Homebrew's `mingw-w64`; it is offered for install on first run.
+  - Re-deploys on **every** launch, because Steam's boot-time checksum pass
+    restores Valve's original binary over the wrapper.
+  - Launches Steam with `MERLOT_CEF_ARGS`, which includes `-noverifyfiles` to
+    stop that checksum pass. Without it the wrapper is evicted and the black
+    window returns. See `wrapper/README.md` for the full analysis.
+- Chromium lock purge:
+  - Deletes stale `Singleton*` / `*.lock` files from the prefix's Steam
+    `htmlcache` when Steam is not running. Left behind by a crash, they trip
+    Chromium's single-instance guard and Steam starts with no window at all.
 - Launch mode:
   - Default (`MERLOT_DETACH=1`) runs Steam with `nohup ... & disown`, redirecting stdout/stderr to `${MERLOT_STEAM_LOG}` (defaults to `${TMPDIR:-/tmp}/merlot-steam.log`). The Terminal window can be closed immediately after launch without killing Steam.
   - `MERLOT_DETACH=0` preserves the pre-patch foreground behavior (Terminal window must stay open).
@@ -79,6 +97,23 @@ Defaults are the values in `run.command`.
   - `0` keeps the old foreground behavior.
 - `MERLOT_STEAM_LOG`
   - Path to the detached-mode Steam log (default: `${TMPDIR:-/tmp}/merlot-steam.log`).
+- `MERLOT_CEF_WRAPPER`
+  - `1` (default) builds/deploys the steamwebhelper wrapper that fixes the black
+    Steam UI. `0` skips it entirely -- expect a black window.
+- `MERLOT_CEF_ARGS`
+  - Flags passed to `steam.exe`
+    (default: `-no-cef-sandbox -cef-single-process -noverifyfiles`).
+  - **`-noverifyfiles` is load-bearing.** Without it Steam's checksum pass
+    restores its own `steamwebhelper.exe` over the wrapper during boot, and the
+    black window comes back on the next launch.
+  - Set to empty to pass no extra flags.
+- `MERLOT_WRAPPER_CACHE`
+  - Where the compiled wrapper is cached
+    (default: `~/.merlot/cef-wrapper/steamwebhelper.exe`). Cached outside the
+    repo so installed `Merlot Apps` bundles can redeploy it without a toolchain.
+- `MERLOT_WRAPPER_AUTO_BREW`
+  - `1` installs `mingw-w64` via Homebrew without prompting. Useful for
+    unattended runs; otherwise the build asks first.
 
 Example overrides (environment variables):
 
@@ -142,8 +177,14 @@ Merlot Apps/
       Resources/
         merlot.env             # Runtime env generated from merlot_configs/*.conf
         run.command            # Copied from repo root at install time
+        wrapper/               # steamwebhelper CEF wrapper (source + installer)
         AppIcon.icns           # Icon for that app
 ```
+
+`run.command` resolves `wrapper/` relative to its own location, so the directory
+has to travel inside each bundle. At launch the bundle normally just redeploys
+the binary cached in `~/.merlot`; the source is shipped so it can rebuild if that
+cache is ever cleared.
 
 ### How it works
 
@@ -173,6 +214,9 @@ cp merlot_configs/template.conf.example merlot_configs/my-game.conf
 
 ### Source files
 
+- `wrapper/` - steamwebhelper CEF wrapper that fixes the black Steam UI
+  (vendored from [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine),
+  MIT; see `wrapper/README.md`)
 - `app/merlot/MerlotLauncher` - shared launcher script for generated apps
 - `app/merlot/AppIcon.icns` - app icon
 - `merlot_configs/*.conf` - per-game launcher metadata and `run.command` environment overrides

--- a/install_merlot.command
+++ b/install_merlot.command
@@ -190,6 +190,14 @@ build_from_config() (
   cp "${SCRIPT_DIR}/run.command" "${build_dir}/Contents/Resources/run.command"
   chmod +x "${build_dir}/Contents/Resources/run.command"
 
+  # run.command resolves the CEF wrapper relative to itself, so it has to travel
+  # inside the bundle. Launches normally just redeploy the cached binary from
+  # ~/.merlot, but shipping the source lets a bundle rebuild it if that is gone.
+  if [[ -d "${SCRIPT_DIR}/wrapper" ]]; then
+    cp -R "${SCRIPT_DIR}/wrapper" "${build_dir}/Contents/Resources/wrapper"
+    chmod +x "${build_dir}/Contents/Resources/wrapper/install-wrapper.sh"
+  fi
+
   write_runtime_env "${build_dir}/Contents/Resources/merlot.env"
 )
 

--- a/run.command
+++ b/run.command
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}"
+# Directory holding this script and the files shipped next to it. Unlike
+# SCRIPT_DIR -- which callers override so the WINEPREFIX alias lands beside the
+# .app bundle -- this always resolves to the repo root, or to Contents/Resources
+# inside a generated Merlot app.
+RUN_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 WINE_VERSION="${WINE_VERSION:-11.10}"
 DXMT_VERSION="${DXMT_VERSION:-0.74}"
@@ -27,6 +32,15 @@ WINE_RETINA_MODE="${WINE_RETINA_MODE:-0}" # 1=enable RetinaMode, 0=disable Retin
 # 0=keep the original foreground behavior (Terminal window must stay open).
 MERLOT_DETACH="${MERLOT_DETACH:-1}"
 MERLOT_STEAM_LOG="${MERLOT_STEAM_LOG:-${TMPDIR:-/tmp}/merlot-steam.log}"
+# Steam's CEF UI renders as a solid black window under Wine on Apple Silicon.
+# 1=install and deploy the steamwebhelper wrapper that fixes it (Default).
+# 0=skip it (expect a black Steam window). See wrapper/README.md.
+MERLOT_CEF_WRAPPER="${MERLOT_CEF_WRAPPER:-1}"
+# Flags passed to steam.exe. -noverifyfiles is required: without it Steam's
+# boot-time checksum pass restores Valve's steamwebhelper.exe over the wrapper
+# and the black window comes back. -no-cef-sandbox is needed because Chromium's
+# sandbox relies on Windows integrity tokens Wine does not model.
+MERLOT_CEF_ARGS="${MERLOT_CEF_ARGS--no-cef-sandbox -cef-single-process -noverifyfiles}"
 # Default before we added this: the value is not set in registry (Wine internal default).
 # Set to force|enable|disable to override, or leave empty to keep default.
 WINE_MOUSE_WARP_OVERRIDE="${WINE_MOUSE_WARP_OVERRIDE:-}"
@@ -275,6 +289,11 @@ enable_dxmt_env() {
 
   export DXMT_LOG_LEVEL="${DXMT_LOG_LEVEL:-error}"
   export WINEDEBUG="${WINEDEBUG:--all,err+all}"
+
+  # bcrypt/ncrypt builtin: Wine's stubs collide with Chromium's BoringSSL.
+  # gameoverlayrenderer disabled: its D3D11 hook deadlocks games under DXMT, and
+  # unchecking the in-game overlay does not stop the DLL being injected.
+  export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:-bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d}"
 }
 
 use_gptk() {
@@ -330,6 +349,51 @@ enable_gptk_env() {
   echo "WINEDLLOVERRIDES=${WINEDLLOVERRIDES}"
 }
 
+ensure_cef_wrapper() {
+  [[ "${MERLOT_CEF_WRAPPER}" == "0" || "${MERLOT_CEF_WRAPPER}" == "1" ]] \
+    || die "MERLOT_CEF_WRAPPER must be 0 or 1."
+
+  if [[ "${MERLOT_CEF_WRAPPER}" == "0" ]]; then
+    log "Skipping steamwebhelper wrapper (MERLOT_CEF_WRAPPER=0)"
+    return
+  fi
+
+  log "Ensuring steamwebhelper wrapper (fixes the black Steam UI)"
+  local installer="${RUN_DIR}/wrapper/install-wrapper.sh"
+  if [[ ! -x "${installer}" ]]; then
+    echo "Wrapper installer not found at ${installer}."
+    echo "Steam's UI will render as a black window. See wrapper/README.md."
+    return
+  fi
+
+  # Steam restores its own helper during boot, so this runs on every launch,
+  # not just the first one. Building only happens when the cache is empty.
+  if WINEPREFIX="${WINEPREFIX}" "${installer}"; then
+    return
+  fi
+
+  echo "Could not install the wrapper; Steam's UI may render black."
+  echo "See wrapper/README.md, or set MERLOT_CEF_WRAPPER=0 to silence this."
+}
+
+purge_chromium_locks() {
+  # A crashed Steam leaves Chromium singleton locks behind; the next launch then
+  # trips the single-instance guard and falls back to --silent, with no window.
+  local htmlcache="${WINEPREFIX}/drive_c/users/${USER}/AppData/Local/Steam/htmlcache"
+  [[ -d "${htmlcache}" ]] || return 0
+
+  # Only safe while Steam is stopped: pulling the lock out from under a live
+  # instance would let a second one start alongside it.
+  if pgrep -f "Steam[\\\\/]steam\.exe" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Purging stale Chromium locks"
+  find "${htmlcache}" -maxdepth 2 \
+    \( -name "Singleton*" -o -name "*.lock" -o -name "CrashpadMetrics*.pma" \) \
+    -delete 2>/dev/null || true
+}
+
 launch_steam() {
   log "Launching Steam"
   local steam_exe
@@ -337,6 +401,12 @@ launch_steam() {
   [[ -n "${steam_exe}" ]] || die "steam.exe not found."
 
   local -a steam_cmd=("${WINE_BIN}" "${steam_exe}")
+  if [[ -n "${MERLOT_CEF_ARGS}" ]]; then
+    # Intentionally unquoted: MERLOT_CEF_ARGS is a space-separated flag list.
+    # shellcheck disable=SC2206
+    local -a cef_args=(${MERLOT_CEF_ARGS})
+    steam_cmd+=("${cef_args[@]}")
+  fi
   if [[ -n "${STEAM_GAME_ID:-}" ]]; then
     echo "Launching Steam game ${STEAM_GAME_ID}..."
     steam_cmd+=(-applaunch "${STEAM_GAME_ID}")
@@ -378,6 +448,8 @@ main() {
     ensure_dxmt_installed
     enable_dxmt_env
   fi
+  ensure_cef_wrapper
+  purge_chromium_locks
   launch_steam
 }
 

--- a/uninstall.command
+++ b/uninstall.command
@@ -11,7 +11,9 @@ STEAM_SETUP="${STEAM_SETUP:-/tmp/SteamSetup.exe}"
 WINEPREFIX_ALIAS_NAME="${WINEPREFIX_ALIAS_NAME:-WINEPREFIX}"
 MERLOT_APPS_DIR_NAME="Merlot Apps"
 SYSTEM_APPLICATIONS_DIR="/Applications"
-TOTAL_STEPS=6
+# Cache for the compiled steamwebhelper CEF wrapper (see wrapper/README.md).
+MERLOT_DATA_DIR="${MERLOT_DATA_DIR:-$HOME/.merlot}"
+TOTAL_STEPS=7
 CURRENT_STEP=0
 
 log() {
@@ -128,6 +130,7 @@ main() {
   echo "4. WINEPREFIX: ${WINEPREFIX}"
   echo "5. DXMT_ROOT: ${DXMT_ROOT}"
   echo "6. WINE_ROOT: ${WINE_ROOT}"
+  echo "7. Merlot data (CEF wrapper cache): ${MERLOT_DATA_DIR}"
 
   log "Removing artifacts from run.command and Merlot app folders"
   remove_file "${STEAM_SETUP}" "Steam installer file"
@@ -136,6 +139,7 @@ main() {
   remove_dir "${WINEPREFIX}" "Wine prefix directory"
   remove_dir "${DXMT_ROOT}" "DXMT directory"
   remove_dir "${WINE_ROOT}" "Wine root directory"
+  remove_dir "${MERLOT_DATA_DIR}" "Merlot data directory (CEF wrapper cache)"
 
   log "Done"
 }

--- a/wrapper/LICENSE.notpop
+++ b/wrapper/LICENSE.notpop
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 notpop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -1,0 +1,26 @@
+#
+# Cross-compile the steamwebhelper wrapper from macOS for Windows x86_64.
+#
+#   make         build ./steamwebhelper.exe
+#   make clean   remove build artefacts
+#
+# Requires Homebrew's mingw-w64 toolchain:
+#   brew install mingw-w64
+#
+# Normally you do not invoke this directly -- build-wrapper.sh does it for you.
+
+TARGET  ?= steamwebhelper.exe
+CC      ?= x86_64-w64-mingw32-gcc
+CFLAGS  ?= -O2 -Wall -Wextra -municode -DUNICODE -D_UNICODE
+LDFLAGS ?= -static -lshell32 -mwindows
+SRC      = src/steamwebhelper-wrapper.c
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)

--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -1,0 +1,75 @@
+# steamwebhelper CEF wrapper
+
+Works around Steam's client UI rendering as a **solid black window** under Wine
+on Apple Silicon.
+
+## The bug
+
+Steam's UI is Chromium (CEF). Under Wine on Apple Silicon:
+
+1. CEF's ANGLE backend tries D3D11 and fails:
+   `Renderer11: Error querying driver version from DXGI Adapter`.
+2. ANGLE falls back to GLES 2.0, but CEF wants 3.0:
+   `eglCreateContext: Requested GLES version (3.0) is greater than max supported (2, 0)`.
+3. CEF disables the GPU and software-renders, and its transparent-background
+   window ends up painted black.
+
+Additionally, CEF's out-of-process `NetworkService` talks TLS through Wine's
+winsock and produces a handshake-failure cascade, which breaks sign-in.
+
+This is **not** caused by DXMT -- the same ANGLE failure occurs with DXMT
+entirely unloaded, because Wine's builtin `d3d11`/`dxgi` hit it too.
+
+## Why a wrapper
+
+Steam's own `-cef-*` flags do not fix it. Of the flags that matter, only
+`-cef-disable-gpu-compositing` is honoured, and it is not sufficient. The flags
+have to be applied to `steamwebhelper.exe` itself, so the wrapper takes that
+binary's place:
+
+- Valve's binary is renamed to `steamwebhelper_real.exe`
+- the wrapper is installed as `steamwebhelper.exe`
+- it injects `--disable-gpu --single-process` and delegates
+
+`--single-process` matters for two independent reasons: it stops the renderer
+opening its own D3D11 swapchain (which paints black), and it collapses the
+`NetworkService` into the browser process, avoiding the winsock TLS cascade.
+
+## `-noverifyfiles` is required too
+
+The wrapper alone is not enough. Steam runs an executable-checksum pass during
+boot that **silently restores Valve's original binary over the wrapper**, so the
+black window returns on the very next launch. `run.command` therefore launches
+Steam with `-noverifyfiles`, and re-deploys the wrapper on every launch.
+
+If you are debugging this, compare file sizes -- the wrapper is ~150 KB, Valve's
+binary is ~7.5 MB:
+
+```bash
+find "$WINEPREFIX/drive_c/Program Files (x86)/Steam/bin/cef" \
+  -name "steamwebhelper*.exe" -exec ls -l {} \;
+```
+
+## Building
+
+Requires Homebrew's `mingw-w64`. `run.command` invokes this automatically, but
+you can run it by hand:
+
+```bash
+./wrapper/install-wrapper.sh              # build if needed, then deploy
+./wrapper/install-wrapper.sh --build-only # build only
+./wrapper/install-wrapper.sh --deploy-only # deploy cached binary
+```
+
+The built binary is cached at `~/.merlot/cef-wrapper/steamwebhelper.exe` so that
+installed `Merlot Apps` bundles can redeploy it without needing the toolchain.
+
+Set `MERLOT_CEF_WRAPPER=0` to disable the wrapper entirely (expect a black UI).
+
+## Credit
+
+`src/steamwebhelper-wrapper.c` is vendored from
+[notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine) and is MIT
+licensed -- see `LICENSE.notpop`. That project diagnosed this bug and the
+`-noverifyfiles` interaction; this directory packages the same fix for this
+repository.

--- a/wrapper/install-wrapper.sh
+++ b/wrapper/install-wrapper.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# install-wrapper.sh -- build and/or deploy the steamwebhelper CEF wrapper.
+#
+# Steam's client UI renders as a solid black window under Wine on Apple
+# Silicon. CEF's ANGLE D3D11 backend cannot query the DXGI adapter, falls back
+# to GLES 2.0 (CEF needs 3.0), disables the GPU, and then paints its
+# transparent-background window black. Steam's own -cef-* flags do not fix it:
+# the flags that matter have to reach steamwebhelper.exe itself.
+#
+# The fix is a small wrapper that takes steamwebhelper.exe's place, injects
+# --disable-gpu --single-process, and delegates to the renamed original.
+#
+# Usage:
+#   install-wrapper.sh                # build if needed, then deploy
+#   install-wrapper.sh --build-only   # build into the cache, do not deploy
+#   install-wrapper.sh --deploy-only  # deploy cached binary (no toolchain needed)
+#
+# Environment:
+#   WINEPREFIX              prefix to deploy into (default ~/.wine-steam-11)
+#   MERLOT_WRAPPER_CACHE    where the built .exe is cached
+#                           (default ~/.merlot/cef-wrapper/steamwebhelper.exe)
+#   MERLOT_WRAPPER_AUTO_BREW=1  install mingw-w64 via Homebrew without asking
+set -euo pipefail
+
+WRAPPER_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WINEPREFIX="${WINEPREFIX:-$HOME/.wine-steam-11}"
+MERLOT_WRAPPER_CACHE="${MERLOT_WRAPPER_CACHE:-$HOME/.merlot/cef-wrapper/steamwebhelper.exe}"
+CEF_ROOT="${WINEPREFIX}/drive_c/Program Files (x86)/Steam/bin/cef"
+
+# Valve's steamwebhelper.exe is a multi-megabyte Chromium bundle; ours is well
+# under 500 KB. Size is how we tell the two apart, which stays correct even
+# when a rebuild changes the wrapper's checksum.
+WRAPPER_SIZE_CEILING=500000
+
+mode="both"
+case "${1:-}" in
+  --build-only)  mode="build" ;;
+  --deploy-only) mode="deploy" ;;
+  "")            mode="both" ;;
+  *) printf "Usage: %s [--build-only|--deploy-only]\n" "$0" >&2; exit 2 ;;
+esac
+
+log() { printf "==> %s\n" "$1"; }
+die() { printf "Error: %s\n" "$1" >&2; exit 1; }
+
+find_mingw() {
+  local candidate
+  candidate="$(command -v x86_64-w64-mingw32-gcc 2>/dev/null || true)"
+  if [[ -n "${candidate}" ]]; then
+    printf "%s\n" "${candidate}"
+    return 0
+  fi
+  if command -v brew >/dev/null 2>&1; then
+    candidate="$(brew --prefix 2>/dev/null)/bin/x86_64-w64-mingw32-gcc"
+    if [[ -x "${candidate}" ]]; then
+      printf "%s\n" "${candidate}"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+ensure_mingw() {
+  local cc
+  if cc="$(find_mingw)"; then
+    printf "%s\n" "${cc}"
+    return 0
+  fi
+
+  command -v brew >/dev/null 2>&1 || die \
+"mingw-w64 is required to build the wrapper, and Homebrew was not found.
+Install Homebrew (https://brew.sh) then run: brew install mingw-w64"
+
+  if [[ "${MERLOT_WRAPPER_AUTO_BREW:-0}" != "1" ]]; then
+    printf "\n" >&2
+    printf "The Steam UI fix needs the mingw-w64 cross-compiler (a few hundred MB).\n" >&2
+    printf "Install it with Homebrew now? [y/N] " >&2
+    local reply=""
+    read -r reply </dev/tty || true
+    case "${reply}" in
+      y|Y|yes|YES) ;;
+      *) die "Declined. Install it yourself with: brew install mingw-w64" ;;
+    esac
+  fi
+
+  log "Installing mingw-w64 via Homebrew"
+  brew install mingw-w64 || die "brew install mingw-w64 failed"
+
+  cc="$(find_mingw)" || die "mingw-w64 still not found after install"
+  printf "%s\n" "${cc}"
+}
+
+build_wrapper() {
+  local cc
+  cc="$(ensure_mingw)"
+
+  log "Building steamwebhelper wrapper"
+  mkdir -p "$(dirname "${MERLOT_WRAPPER_CACHE}")"
+  make -C "${WRAPPER_DIR}" clean >/dev/null 2>&1 || true
+  make -C "${WRAPPER_DIR}" CC="${cc}" >/dev/null \
+    || die "Wrapper build failed"
+
+  [[ -f "${WRAPPER_DIR}/steamwebhelper.exe" ]] \
+    || die "Wrapper binary missing after build"
+
+  mv -f "${WRAPPER_DIR}/steamwebhelper.exe" "${MERLOT_WRAPPER_CACHE}"
+  echo "Built ${MERLOT_WRAPPER_CACHE} ($(wc -c < "${MERLOT_WRAPPER_CACHE}" | tr -d ' ') bytes)"
+}
+
+is_wrapper_like() {
+  local path="$1"
+  [[ -f "${path}" ]] || return 1
+  (( $(stat -f%z "${path}") < WRAPPER_SIZE_CEILING ))
+}
+
+deploy_wrapper() {
+  [[ -f "${MERLOT_WRAPPER_CACHE}" ]] \
+    || die "No wrapper binary at ${MERLOT_WRAPPER_CACHE}. Run: $0 --build-only"
+  [[ -d "${CEF_ROOT}" ]] \
+    || die "Steam CEF directory not found: ${CEF_ROOT}"
+
+  local installed=0 cef_dir target real
+  while IFS= read -r -d '' cef_dir; do
+    target="${cef_dir}/steamwebhelper.exe"
+    real="${cef_dir}/steamwebhelper_real.exe"
+
+    if [[ ! -f "${target}" ]]; then
+      echo "No steamwebhelper.exe in ${cef_dir}. Skipping."
+      continue
+    fi
+
+    if is_wrapper_like "${target}"; then
+      # Never copy a wrapper over the stash -- that would destroy Valve's binary.
+      if [[ ! -f "${real}" ]] || is_wrapper_like "${real}"; then
+        die "${cef_dir}: Valve's original steamwebhelper.exe is gone. Reinstall Steam to recover."
+      fi
+    else
+      # target is Valve's. Preserve it before we overwrite.
+      if [[ ! -f "${real}" ]] || is_wrapper_like "${real}"; then
+        cp "${target}" "${real}" || die "Failed to stash Valve binary to ${real}"
+      elif [[ "$(md5 -q "${target}")" != "$(md5 -q "${real}")" ]]; then
+        # Steam updated its helper; refresh the stash so we delegate to the
+        # current build rather than a stale one.
+        cp "${target}" "${real}" || die "Failed to refresh ${real}"
+      fi
+    fi
+
+    cp "${MERLOT_WRAPPER_CACHE}" "${target}" || die "Failed to install wrapper to ${target}"
+    installed=$((installed + 1))
+  done < <(find "${CEF_ROOT}" -maxdepth 1 -type d -name "cef.win*" -print0)
+
+  (( installed > 0 )) || die "No cef.win* directories found under ${CEF_ROOT}"
+  log "Wrapper active in ${installed} CEF directory/directories"
+}
+
+case "${mode}" in
+  build)  build_wrapper ;;
+  deploy) deploy_wrapper ;;
+  both)
+    [[ -f "${MERLOT_WRAPPER_CACHE}" ]] || build_wrapper
+    deploy_wrapper
+    ;;
+esac

--- a/wrapper/src/steamwebhelper-wrapper.c
+++ b/wrapper/src/steamwebhelper-wrapper.c
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * steamwebhelper-wrapper — prepend Chromium flags and delegate to the
+ * real Steam webhelper binary. Used on macOS / Apple Silicon to work
+ * around black-screen rendering and Wine winsock issues that otherwise
+ * kill Steam's CEF UI on DXMT. See EXTRA_FLAGS below for the current
+ * flag set and the reasoning behind each.
+ *
+ * Build
+ * -----
+ *   make -C wrapper
+ * which invokes x86_64-w64-mingw32-gcc (from Homebrew mingw-w64) with:
+ *   -municode -O2 -Wall -Wextra -static -lshell32 -mwindows
+ *
+ * Install
+ * -------
+ *   1. Rename Steam's original file:
+ *        steamwebhelper.exe -> steamwebhelper_real.exe
+ *   2. Drop the compiled wrapper in its place as steamwebhelper.exe
+ *
+ * Runtime behaviour
+ * -----------------
+ *   - Resolves its own directory via GetModuleFileNameW
+ *   - Builds the child command line in the form:
+ *         "<dir>\\steamwebhelper_real.exe" <EXTRA_FLAGS> <original args>
+ *   - Calls CreateProcessW, waits, and returns the child's exit code.
+ *
+ * Notes
+ * -----
+ *   - All string handling is wide-character; Chromium's internal args
+ *     include Unicode paths like
+ *     C:\users\notpop\AppData\Local\Steam\htmlcache.
+ *   - Uses -mwindows so Windows treats the wrapper as a GUI app (same
+ *     subsystem Steam's original helper declares). Debug prints go to
+ *     a log file next to the wrapper if STEAMWEBHELPER_WRAPPER_DEBUG
+ *     is set in the environment.
+ */
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+/*
+ * Flags prepended to every invocation of steamwebhelper_real.exe.
+ *
+ * --disable-gpu
+ *     Force Chromium CPU rasterisation. With the GPU process enabled
+ *     CEF hits an ANGLE / D3D-over-OpenGL path that paints the browser
+ *     window black on Wine/Apple Silicon (DXMT Issue #141). CPU raster
+ *     via Skia is sufficient for Steam's 2D UI.
+ *
+ * --single-process
+ *     Collapse renderer / utility / gpu back into the browser process.
+ *     Without this flag:
+ *       - The renderer process opens its own D3D11 swapchain and hits
+ *         the cross-process limitation in DXMT Issue #141, painting the
+ *         browser window black.
+ *       - The NetworkService runs in a separate utility process and
+ *         talks TLS via Wine's winsock implementation, which triggers
+ *         the `handshake failed; net_error -100 / -107` cascade.
+ *     We tried the narrower `--enable-features=NetworkServiceInProcess`
+ *     alone but CEF 126 in Steam ignored it — a utility process
+ *     labelled `network.mojom.NetworkService` still spawned, the SSL
+ *     cascade still fired, and the renderer still painted black.
+ *     Until there is a Chromium-supported single-flag replacement for
+ *     `--single-process`, this is the only configuration that keeps
+ *     Steam's CEF UI responsive and authenticated on Wine 11.
+ *
+ *     On the DXMT side, `winemetal_unix.c::_CreateMetalViewFromHWND`
+ *     does its AppKit work directly when it's already on the main
+ *     thread (Unity-style engines call CreateSwapChainForHwnd from the
+ *     main thread), which avoids the deadlock we hit when naively
+ *     dispatching through Wine's `OnMainThread`. See the comment there
+ *     for details; the upshot is that `--single-process` does not by
+ *     itself block the Metal view handover, contrary to what we
+ *     suspected during the v0.5 investigation.
+ */
+#define EXTRA_FLAGS  L"--disable-gpu --single-process"
+#define REAL_BINARY  L"steamwebhelper_real.exe"
+
+/*
+ * Debug sink. Enabled when the environment variable
+ * STEAMWEBHELPER_WRAPPER_DEBUG is set to a non-empty value.
+ * Opens a file next to the wrapper so we can inspect behaviour
+ * even though the wrapper is a GUI subsystem binary.
+ */
+static FILE *dbg = NULL;
+
+static void debug_open(const wchar_t *self_path)
+{
+    const wchar_t *flag = _wgetenv(L"STEAMWEBHELPER_WRAPPER_DEBUG");
+    if (!flag || !*flag) return;
+
+    wchar_t log_path[MAX_PATH];
+    if (wcslen(self_path) + 16 >= MAX_PATH) return;
+    wcscpy(log_path, self_path);
+
+    wchar_t *slash = wcsrchr(log_path, L'\\');
+    if (!slash) return;
+    wcscpy(slash + 1, L"wrapper-debug.log");
+
+    dbg = _wfopen(log_path, L"a");
+}
+
+static void debug_log(const wchar_t *fmt, ...)
+{
+    if (!dbg) return;
+    va_list ap;
+    va_start(ap, fmt);
+    vfwprintf(dbg, fmt, ap);
+    va_end(ap);
+    fflush(dbg);
+}
+
+/* Allocate a wide string holding "<wrapper_dir>\\steamwebhelper_real.exe". */
+static wchar_t *resolve_real_binary(wchar_t *out_self_dir, size_t out_cap)
+{
+    wchar_t self[MAX_PATH];
+    DWORD len = GetModuleFileNameW(NULL, self, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH) return NULL;
+
+    if (out_self_dir && wcslen(self) < out_cap) {
+        wcscpy(out_self_dir, self);
+    }
+
+    wchar_t *slash = wcsrchr(self, L'\\');
+    if (!slash) return NULL;
+    *(slash + 1) = L'\0';
+
+    size_t cap = wcslen(self) + wcslen(REAL_BINARY) + 1;
+    wchar_t *real = (wchar_t *)calloc(cap, sizeof(wchar_t));
+    if (!real) return NULL;
+    wcscpy(real, self);
+    wcscat(real, REAL_BINARY);
+    return real;
+}
+
+/*
+ * GetCommandLineW returns the whole line, starting with the wrapper
+ * binary's own path. We skip past that first token to return just the
+ * arguments Steam actually passed.
+ */
+static const wchar_t *args_tail(void)
+{
+    const wchar_t *cmd = GetCommandLineW();
+    if (!cmd) return L"";
+
+    int in_quotes = 0;
+    while (*cmd) {
+        wchar_t c = *cmd;
+        if (c == L'"') in_quotes = !in_quotes;
+        else if (c == L' ' && !in_quotes) break;
+        ++cmd;
+    }
+    while (*cmd == L' ') ++cmd;
+    return cmd;
+}
+
+int wmain(void)
+{
+    wchar_t self_path[MAX_PATH] = {0};
+    wchar_t *real = resolve_real_binary(self_path, MAX_PATH);
+    if (!real) {
+        return 1;
+    }
+
+    debug_open(self_path);
+    debug_log(L"[wrapper] self=%ls\n", self_path);
+    debug_log(L"[wrapper] real=%ls\n", real);
+
+    const wchar_t *tail = args_tail();
+    debug_log(L"[wrapper] forwarded args=%ls\n", tail);
+
+    size_t cap = wcslen(real) + wcslen(EXTRA_FLAGS) + wcslen(tail) + 8;
+    wchar_t *cmdline = (wchar_t *)calloc(cap, sizeof(wchar_t));
+    if (!cmdline) {
+        free(real);
+        return 1;
+    }
+    _snwprintf(cmdline, cap, L"\"%ls\" %ls %ls", real, EXTRA_FLAGS, tail);
+    debug_log(L"[wrapper] invoking: %ls\n", cmdline);
+
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    BOOL ok = CreateProcessW(
+        real,       /* lpApplicationName */
+        cmdline,    /* lpCommandLine     */
+        NULL,       /* lpProcessAttributes */
+        NULL,       /* lpThreadAttributes  */
+        TRUE,       /* bInheritHandles     */
+        0,          /* dwCreationFlags     */
+        NULL,       /* lpEnvironment       */
+        NULL,       /* lpCurrentDirectory  */
+        &si,
+        &pi
+    );
+
+    if (!ok) {
+        DWORD err = GetLastError();
+        debug_log(L"[wrapper] CreateProcessW failed: %lu\n", err);
+        free(cmdline);
+        free(real);
+        return 1;
+    }
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD code = 0;
+    GetExitCodeProcess(pi.hProcess, &code);
+    debug_log(L"[wrapper] child exited with %lu\n", code);
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    free(cmdline);
+    free(real);
+    if (dbg) fclose(dbg);
+
+    return (int)code;
+}


### PR DESCRIPTION
Steam's CEF interface paints a solid black window under Wine on Apple Silicon, which makes the client unusable: you cannot reach the login screen at all.

Cause: CEF's ANGLE backend fails to query the DXGI adapter ("Renderer11: Error querying driver version from DXGI Adapter"), falls back to GLES 2.0 when CEF requires 3.0, disables the GPU, and then software-renders its transparent-background window as black. This is not DXMT-specific -- Wine's builtin d3d11/dxgi hit the same failure, and the black window reproduces with DXMT entirely unloaded.

Steam's own -cef-* flags do not fix it; only -cef-disable-gpu-compositing is honoured and it is insufficient. The flags have to reach steamwebhelper.exe itself, so this vendors the wrapper from notpop/steam-on-m1-wine (MIT): it takes that binary's place, injects --disable-gpu --single-process, and delegates to the renamed original. --single-process is needed twice over -- it stops the renderer opening its own D3D11 swapchain, and collapses the out-of-process NetworkService that otherwise fails TLS through Wine's winsock and breaks sign-in.

The wrapper alone is not enough. Steam runs an executable-checksum pass during boot that silently restores its own binary over the wrapper, so the black window returns on the next launch. run.command therefore launches with -noverifyfiles and re-deploys the wrapper every time.

Also included:
- Purge stale Chromium singleton locks while Steam is stopped; left by a crash they trip the single-instance guard and Steam starts with no window at all.
- Force builtin bcrypt/ncrypt (Wine's stubs collide with Chromium's BoringSSL) and disable gameoverlayrenderer, whose D3D11 hook deadlocks games under DXMT even when the in-game overlay is unchecked.
- Ship wrapper/ inside generated Merlot app bundles, since run.command resolves it relative to itself.
- uninstall.command removes the wrapper cache in ~/.merlot.

Opt out with MERLOT_CEF_WRAPPER=0. Building needs Homebrew's mingw-w64, which the installer offers to install on first run.